### PR TITLE
feat: Active workout UX (#77, #81, #79)

### DIFF
--- a/app/actions/exercises.ts
+++ b/app/actions/exercises.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 
 import type { StretchKind, TrackingType } from "@/lib/database.types";
 import { createClient } from "@/lib/supabase/server";
+import { syncExerciseToActiveDraft } from "@/app/actions/workouts";
 
 export async function updateExercise(input: {
   id: string;
@@ -92,6 +93,10 @@ export async function updateExercise(input: {
     if (insertErr) throw new Error(insertErr.message);
   }
 
+  for (const splitName of newSplitNames) {
+    await syncExerciseToActiveDraft(input.id, splitName);
+  }
+
   revalidatePath("/settings/exercises");
   revalidatePath("/workout/start");
   revalidatePath("/progress");
@@ -153,6 +158,10 @@ export async function createExercise(input: {
       await supabase.from("exercises").delete().eq("id", inserted.id);
       throw new Error(insertErr.message);
     }
+  }
+
+  for (const splitName of input.splits) {
+    await syncExerciseToActiveDraft(inserted.id, splitName.trim());
   }
 
   revalidatePath("/settings/exercises");

--- a/app/actions/workouts.ts
+++ b/app/actions/workouts.ts
@@ -96,6 +96,85 @@ async function fetchLatestCompletedSetsByExercise(
   );
 }
 
+type ExerciseDraftSource = {
+  id: string;
+  default_sets: number;
+  default_reps: number | null;
+  progressive_overload_increment: number | null;
+  tracking_type: string | null;
+  machine_start_weight: number | null;
+  machine_end_weight: number | null;
+  machine_increment: number | null;
+};
+
+function buildDraftSetInsertRows(
+  workoutId: string,
+  exercise: ExerciseDraftSource,
+  bodyWeight: number | null,
+  previousByKey: Record<string, number | null>,
+  latestPerfByExercise: Record<string, CompletedSetPerf[]>,
+) {
+  const tt = (exercise.tracking_type ?? "weighted") as TrackingType;
+  const incrementConfigured =
+    exercise.progressive_overload_increment == null
+      ? null
+      : Number(exercise.progressive_overload_increment);
+  const defaultReps =
+    exercise.default_reps != null ? Number(exercise.default_reps) : null;
+  const latestSets = latestPerfByExercise[exercise.id] ?? [];
+  const latestSetByNumber = new Map(
+    latestSets.map((s) => [s.set_number, s]),
+  );
+
+  return Array.from({ length: exercise.default_sets }, (_, i) => {
+    const set_number = i + 1;
+    const key = `${exercise.id}:${set_number}`;
+    const lastW = previousByKey[key] ?? null;
+    const reps = defaultReps;
+
+    const progressionDirection = resolveSetProgressionDirection(
+      latestSetByNumber.get(set_number) ?? null,
+      defaultReps,
+      SMART_PROGRESSION_RIR_TARGET,
+    );
+
+    let weight: number | null = null;
+    if (usesLoggedWeightColumn(tt)) {
+      if (incrementConfigured != null) {
+        weight = applyFixedIncrement(
+          lastW,
+          incrementConfigured,
+          progressionDirection,
+          exercise.machine_start_weight,
+          exercise.machine_end_weight,
+          exercise.machine_increment,
+          tt,
+        );
+      } else {
+        weight = lastW;
+      }
+      if (tt === "bodyweight" && weight == null) {
+        weight = 0;
+      }
+    }
+
+    const volume = computeSetVolume(tt, {
+      reps,
+      weight,
+      bodyWeight,
+    });
+
+    return {
+      workout_id: workoutId,
+      exercise_id: exercise.id,
+      set_number,
+      reps,
+      weight,
+      volume,
+    };
+  });
+}
+
 export async function createWorkoutDraftAndRedirect(split: string) {
   const splitName = split.trim();
   if (!splitName) throw new Error("Choose a split");
@@ -177,70 +256,15 @@ export async function createWorkoutDraftAndRedirect(split: string) {
   const bodyWeight =
     profile?.body_weight == null ? null : Number(profile.body_weight);
 
-  const rows = exercises.flatMap((ex) => {
-    const tt = (ex.tracking_type ?? "weighted") as TrackingType;
-    const incrementConfigured =
-      ex.progressive_overload_increment == null
-        ? null
-        : Number(ex.progressive_overload_increment);
-    const defaultReps = ex.default_reps != null ? Number(ex.default_reps) : null;
-    const latestSets = latestPerfByExercise[ex.id] ?? [];
-    const latestSetByNumber = new Map(
-      latestSets.map((s) => [s.set_number, s]),
-    );
-
-    return Array.from({ length: ex.default_sets }, (_, i) => {
-      const set_number = i + 1;
-      const key = `${ex.id}:${set_number}`;
-      const lastW = previousByKey[key] ?? null;
-      const reps = defaultReps;
-
-      // Resolve progression direction per-set — one weak/missing set no
-      // longer blocks progression for the others (#69, #70).
-      const progressionDirection = resolveSetProgressionDirection(
-        latestSetByNumber.get(set_number) ?? null,
-        defaultReps,
-        SMART_PROGRESSION_RIR_TARGET,
-      );
-
-      let weight: number | null = null;
-      if (usesLoggedWeightColumn(tt)) {
-        if (incrementConfigured != null) {
-          // Use fixed increment for this exercise
-          weight = applyFixedIncrement(
-            lastW,
-            incrementConfigured,
-            progressionDirection,
-            ex.machine_start_weight,
-            ex.machine_end_weight,
-            ex.machine_increment,
-            tt,
-          );
-        } else {
-          // No progression configured
-          weight = lastW;
-        }
-        if (tt === "bodyweight" && weight == null) {
-          weight = 0;
-        }
-      }
-
-      const volume = computeSetVolume(tt, {
-        reps,
-        weight,
-        bodyWeight,
-      });
-
-      return {
-        workout_id: workout.id,
-        exercise_id: ex.id,
-        set_number,
-        reps,
-        weight,
-        volume,
-      };
-    });
-  });
+  const rows = exercises.flatMap((ex) =>
+    buildDraftSetInsertRows(
+      workout.id,
+      ex,
+      bodyWeight,
+      previousByKey,
+      latestPerfByExercise,
+    ),
+  );
 
   const { error: sErr } = await supabase.from("workout_sets").insert(rows);
   if (sErr) {
@@ -552,6 +576,9 @@ export async function addWorkoutSet(
       // No progression configured
       weight = lastW;
     }
+    if (trackingType === "bodyweight" && weight == null) {
+      weight = 0;
+    }
   }
 
   const volume = computeSetVolume(trackingType, {
@@ -626,6 +653,80 @@ export async function removeWorkoutSet(setId: string, workoutId: string) {
   if (error) throw new Error(error.message);
 
   revalidatePath(`/workout/${workoutId}`);
+  revalidatePath("/");
+}
+
+/**
+ * When an exercise is added to a split that has an active draft workout,
+ * append its default sets so the in-progress session stays in sync (#79).
+ */
+export async function syncExerciseToActiveDraft(
+  exerciseId: string,
+  splitName: string,
+): Promise<void> {
+  const trimmed = splitName.trim();
+  if (!trimmed) return;
+
+  const supabase = await createClient();
+
+  const { data: draft, error: dErr } = await supabase
+    .from("workouts")
+    .select("id, date, split")
+    .eq("split", trimmed)
+    .eq("status", "draft")
+    .maybeSingle();
+  if (dErr) throw new Error(dErr.message);
+  if (!draft) return;
+
+  const { count, error: countErr } = await supabase
+    .from("workout_sets")
+    .select("id", { count: "exact", head: true })
+    .eq("workout_id", draft.id)
+    .eq("exercise_id", exerciseId);
+  if (countErr) throw new Error(countErr.message);
+  if ((count ?? 0) > 0) return;
+
+  const { data: exercise, error: exErr } = await supabase
+    .from("exercises")
+    .select(
+      "id, default_sets, default_reps, progressive_overload_increment, tracking_type, machine_start_weight, machine_end_weight, machine_increment",
+    )
+    .eq("id", exerciseId)
+    .single();
+  if (exErr || !exercise) {
+    throw new Error(exErr?.message ?? "Exercise not found");
+  }
+
+  const [{ data: profile }, previousByKey, latestPerfByExercise] =
+    await Promise.all([
+      supabase
+        .from("user_training_profile")
+        .select("body_weight")
+        .eq("singleton", true)
+        .maybeSingle(),
+      fetchPreviousWeightsBeforeDate(draft.date, [exerciseId]),
+      fetchLatestCompletedSetsByExercise(draft.date, [exerciseId], draft.split),
+    ]);
+
+  const bodyWeight =
+    profile?.body_weight == null ? null : Number(profile.body_weight);
+
+  const insertRows = buildDraftSetInsertRows(
+    draft.id,
+    exercise,
+    bodyWeight,
+    previousByKey,
+    latestPerfByExercise,
+  );
+
+  if (insertRows.length === 0) return;
+
+  const { error: insertErr } = await supabase
+    .from("workout_sets")
+    .insert(insertRows);
+  if (insertErr) throw new Error(insertErr.message);
+
+  revalidatePath(`/workout/${draft.id}`);
   revalidatePath("/");
 }
 

--- a/app/actions/workouts.ts
+++ b/app/actions/workouts.ts
@@ -220,6 +220,9 @@ export async function createWorkoutDraftAndRedirect(split: string) {
           // No progression configured
           weight = lastW;
         }
+        if (tt === "bodyweight" && weight == null) {
+          weight = 0;
+        }
       }
 
       const volume = computeSetVolume(tt, {
@@ -597,6 +600,28 @@ export async function addWorkoutSet(
 
 export async function removeWorkoutSet(setId: string, workoutId: string) {
   const supabase = await createClient();
+
+  const { data: target, error: fetchErr } = await supabase
+    .from("workout_sets")
+    .select("exercise_id")
+    .eq("id", setId)
+    .eq("workout_id", workoutId)
+    .maybeSingle();
+  if (fetchErr) throw new Error(fetchErr.message);
+  if (!target) throw new Error("Set not found");
+
+  const { count, error: countErr } = await supabase
+    .from("workout_sets")
+    .select("id", { count: "exact", head: true })
+    .eq("workout_id", workoutId)
+    .eq("exercise_id", target.exercise_id);
+  if (countErr) throw new Error(countErr.message);
+  if ((count ?? 0) <= 1) {
+    throw new Error(
+      "Cannot remove the last set for this exercise. Add another set first, or remove the exercise from Settings.",
+    );
+  }
+
   const { error } = await supabase.from("workout_sets").delete().eq("id", setId);
   if (error) throw new Error(error.message);
 

--- a/components/ui/modal.tsx
+++ b/components/ui/modal.tsx
@@ -18,6 +18,8 @@ type Props = {
   closeOnBackdrop?: boolean;
   /** When false, Escape does not dismiss. Default true. */
   closeOnEscape?: boolean;
+  /** When true, the confirm button is disabled (e.g. finish blocked until sets are Done). */
+  confirmDisabled?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 };
@@ -32,6 +34,7 @@ export function Modal({
   variant = "primary",
   closeOnBackdrop = true,
   closeOnEscape = true,
+  confirmDisabled = false,
   onConfirm,
   onCancel,
 }: Props) {
@@ -112,6 +115,7 @@ export function Modal({
           <Button
             variant={variant === "danger" ? "danger" : "primary"}
             type="button"
+            disabled={confirmDisabled}
             onClick={onConfirm}
           >
             {confirmLabel}

--- a/components/workout/ActiveWorkout.tsx
+++ b/components/workout/ActiveWorkout.tsx
@@ -20,6 +20,7 @@ import {
   RIR_PRESETS,
   buildMachineWeightPresets,
   mergeNumberOptions,
+  mergeWeightOptions,
   weightColumnTitle,
   weightHeader,
 } from "@/components/workout/setFieldPresets";
@@ -98,7 +99,7 @@ function SetTableRow({
 
   const tt = row.tracking_type;
   const repsOptions = mergeNumberOptions(REPS_PRESETS, reps);
-  const weightOptions = mergeNumberOptions(weightPresets, weight);
+  const weightOptions = mergeWeightOptions(tt, weightPresets, weight);
   const rirOptions = mergeNumberOptions(RIR_PRESETS, rir);
   const durationOptions = mergeNumberOptions(DURATION_PRESETS, duration);
 
@@ -714,6 +715,17 @@ export function ActiveWorkout({
 
   /** Defer opening the confirm modal so the same pointer gesture cannot "land" on the backdrop and dismiss it (mobile / touch). */
   const requestRemoveSet = (setId: string) => {
+    const row = localRows.find((r) => r.id === setId);
+    if (!row) return;
+    const setsForExercise = localRows.filter(
+      (r) => r.exercise_id === row.exercise_id,
+    ).length;
+    if (setsForExercise <= 1) {
+      setError(
+        "Cannot remove the last set for this exercise. Add another set first.",
+      );
+      return;
+    }
     window.setTimeout(() => setRemoveTarget(setId), 0);
   };
 
@@ -938,7 +950,7 @@ export function ActiveWorkout({
       <Modal
         open={!!removeTarget}
         title="Remove this set?"
-        description="This deletes the set row for this workout."
+        description="Removes this set row from today's workout only. The exercise stays in your split settings."
         variant="danger"
         confirmLabel="Remove set"
         onCancel={() => setRemoveTarget(null)}

--- a/components/workout/ActiveWorkout.tsx
+++ b/components/workout/ActiveWorkout.tsx
@@ -29,13 +29,14 @@ import { WorkoutSummary } from "@/components/workout/WorkoutSummary";
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
 import type { SetType, StretchKind, TrackingType } from "@/lib/database.types";
-import { formatUndoneSetsMessage } from "@/lib/setCompletion";
+import { formatUndoneSetsMessage, getFinishModalState } from "@/lib/setCompletion";
 import { useCountdown } from "@/lib/useCountdown";
 
 const NOTE_PREVIEW_MAX = 36;
 
 const REST_STORAGE_PREFIX = "gym-app:rest:";
 const VIEW_MODE_STORAGE_PREFIX = "gym-app:viewMode:";
+const FOCUS_STEP_STORAGE_PREFIX = "gym-app:focusStep:";
 
 type ViewMode = "list" | "focus";
 
@@ -526,6 +527,7 @@ export function ActiveWorkout({
   const readOnly = status === "completed";
   const restStorageKey = `${REST_STORAGE_PREFIX}${workoutId}`;
   const viewModeStorageKey = `${VIEW_MODE_STORAGE_PREFIX}${workoutId}`;
+  const focusStepStorageKey = `${FOCUS_STEP_STORAGE_PREFIX}${workoutId}`;
 
   // Rest timer persisted as an absolute epoch so it survives tab
   // backgrounding, throttling, and page refresh (#67).
@@ -556,6 +558,13 @@ export function ActiveWorkout({
   } | null>(null);
 
   const [localRows, setLocalRows] = useState(() => rows);
+
+  // Pick up server-refreshed rows (e.g. exercise added to split mid-workout, #79).
+  useEffect(() => {
+    setLocalRows(rows);
+  }, [rows]);
+
+  const focusRestoredRef = useRef(false);
 
   // Rest should only fire the first time a set is marked Done — re-editing
   // and re-completing a set (Edit → Done again) is a correction, not a new
@@ -594,6 +603,11 @@ export function ActiveWorkout({
   const groups = useMemo(() => groupFlatSets(localRows), [localRows]);
   const focusSteps = useMemo(() => buildFocusSteps(groups), [groups]);
 
+  const finishModalState = useMemo(
+    () => getFinishModalState(localRows),
+    [localRows],
+  );
+
   const setViewModePersisted = (mode: ViewMode) => {
     setViewMode(mode);
     window.sessionStorage.setItem(viewModeStorageKey, mode);
@@ -605,6 +619,40 @@ export function ActiveWorkout({
       Notification.requestPermission();
     }
   }, []);
+
+  // Restore Focus position after leaving and returning to the workout (#77).
+  useEffect(() => {
+    if (readOnly || focusRestoredRef.current || focusSteps.length === 0) return;
+    focusRestoredRef.current = true;
+
+    const saved = window.sessionStorage.getItem(focusStepStorageKey);
+    if (saved) {
+      const idx = focusSteps.findIndex((s) => s.setId === saved);
+      if (idx >= 0) {
+        setFocusIndex(idx);
+        return;
+      }
+    }
+
+    const firstIncomplete = focusSteps.findIndex((step) => {
+      const row = localRows.find((r) => r.id === step.setId);
+      return row && row.set_type !== "warmup" && row.completed_at == null;
+    });
+    if (firstIncomplete >= 0) {
+      setFocusIndex(firstIncomplete);
+    }
+  }, [focusSteps, localRows, readOnly, focusStepStorageKey]);
+
+  // Refresh server rows when returning to the tab (e.g. after settings sync, #79).
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === "visible") {
+        router.refresh();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [router]);
 
   /** Play audio/haptic feedback for rest completion. */
   const playRestAlert = useCallback(() => {
@@ -781,6 +829,13 @@ export function ActiveWorkout({
   const clampedFocusIndex =
     focusSteps.length > 0 ? Math.min(focusIndex, focusSteps.length - 1) : 0;
   const focusStep = focusSteps[clampedFocusIndex] ?? null;
+
+  // Persist the current Focus step so navigation away does not reset position (#77).
+  useEffect(() => {
+    if (readOnly || !focusStep) return;
+    window.sessionStorage.setItem(focusStepStorageKey, focusStep.setId);
+  }, [focusStep, readOnly, focusStepStorageKey]);
+
   const focusRow = focusStep
     ? localRows.find((r) => r.id === focusStep.setId) ?? null
     : null;
@@ -884,7 +939,9 @@ export function ActiveWorkout({
             stepIndex={clampedFocusIndex}
             totalSteps={focusSteps.length}
             onBack={() => setFocusIndex((i) => Math.max(0, i - 1))}
-            onNext={() => setFocusIndex((i) => Math.min(i + 1, focusSteps.length - 1))}
+            onNext={() =>
+              setFocusIndex((i) => Math.min(i + 1, focusSteps.length - 1))
+            }
             onDoneRest={focusOnDoneRest}
             onOpenNote={() =>
               setFocusNoteTarget({ setId: focusRow.id, draft: focusRow.note ?? "" })
@@ -959,11 +1016,13 @@ export function ActiveWorkout({
 
       <Modal
         open={finishOpen}
-        title="Finish workout?"
-        description="Marks this session complete and returns home. You can review it in History."
-        confirmLabel="Finish workout"
+        title={finishModalState.title}
+        description={finishModalState.description}
+        confirmLabel={finishModalState.confirmLabel}
+        confirmDisabled={!finishModalState.canFinish}
         onCancel={() => setFinishOpen(false)}
         onConfirm={() => {
+          if (!finishModalState.canFinish) return;
           setFinishOpen(false);
           onFinish();
         }}

--- a/components/workout/FocusSetCard.tsx
+++ b/components/workout/FocusSetCard.tsx
@@ -7,6 +7,7 @@ import {
   REPS_PRESETS,
   RIR_PRESETS,
   mergeNumberOptions,
+  mergeWeightOptions,
   weightColumnTitle,
   weightHeader,
 } from "@/components/workout/setFieldPresets";
@@ -61,7 +62,6 @@ export function FocusSetCard({
     setRir,
     duration,
     setDuration,
-    volumeLocal,
     isDone,
     readyToComplete,
     markDonePending,
@@ -76,7 +76,7 @@ export function FocusSetCard({
 
   const tt = row.tracking_type;
   const repsOptions = mergeNumberOptions(REPS_PRESETS, reps);
-  const weightOptions = mergeNumberOptions(weightPresets, weight);
+  const weightOptions = mergeWeightOptions(tt, weightPresets, weight);
   const rirOptions = mergeNumberOptions(RIR_PRESETS, rir);
   const durationOptions = mergeNumberOptions(DURATION_PRESETS, duration);
 
@@ -220,12 +220,11 @@ export function FocusSetCard({
           ) : null}
         </div>
 
-        <div className="mt-4 flex items-center justify-between text-sm text-[var(--gray-600)] dark:text-[var(--gray-400)]">
-          <span>Vol {volumeLocal == null ? "—" : Math.round(volumeLocal).toLocaleString()}</span>
+        <div className="mt-4 flex justify-end text-sm text-[var(--gray-600)] dark:text-[var(--gray-400)]">
           <button
             type="button"
             onClick={onOpenNote}
-            className="max-w-[60%] truncate text-left underline decoration-dotted"
+            className="max-w-full truncate text-left underline decoration-dotted"
           >
             {savedNote.trim() ? savedNote : "Add note…"}
           </button>

--- a/components/workout/setFieldPresets.ts
+++ b/components/workout/setFieldPresets.ts
@@ -53,3 +53,13 @@ export function mergeNumberOptions(presets: number[], current: string): number[]
     .filter((v) => Number.isFinite(v))
     .sort((a, b) => a - b);
 }
+
+/** Weight dropdown options — bodyweight always includes 0 (no extra weight). */
+export function mergeWeightOptions(
+  trackingType: TrackingType,
+  presets: number[],
+  current: string,
+): number[] {
+  const base = trackingType === "bodyweight" ? [0, ...presets] : presets;
+  return mergeNumberOptions(base, current);
+}

--- a/docs/cardio-tracking-plan.md
+++ b/docs/cardio-tracking-plan.md
@@ -1,0 +1,280 @@
+# Cardio Tracking Plan (#83)
+
+**Status:** Planning only — not implemented  
+**Created:** 2026-07-12  
+**Related issue:** [swesan123/gym-app#83](https://github.com/swesan123/gym-app/issues/83)
+
+## Goal
+
+Add cardio activities (running, cycling, rowing, etc.) as a first-class exercise category in the gym app — modeled like stretches today, not as a separate `runs` table. Cardio exercises live in splits, log during active workouts, and show cardio-specific progress charts.
+
+## Design principle: mirror the stretch pattern
+
+Stretches use `stretch_kind` (`none` | `dynamic` | `static`) on `exercises` to change UI sections, validation, and progress exclusion. Cardio should follow the same pattern with a new `cardio_kind` (or extended `stretch_kind`) field rather than a standalone running module.
+
+```mermaid
+flowchart TB
+  subgraph today [Current pattern]
+    Exercise[exercises table]
+    StretchKind["stretch_kind: none | dynamic | static"]
+    SplitJunction[exercise_splits]
+    WorkoutSets[workout_sets during active workout]
+    Exercise --> StretchKind
+    Exercise --> SplitJunction
+    SplitJunction --> WorkoutSets
+  end
+
+  subgraph proposed [Proposed cardio pattern]
+    CardioKind["cardio_kind: none | distance | duration | goal"]
+    CardioFields[cardio-specific set fields]
+    CardioProgress[cardio progress views]
+    Exercise --> CardioKind
+    WorkoutSets --> CardioFields
+    CardioFields --> CardioProgress
+  end
+```
+
+---
+
+## Apple Fitness reference (workout type taxonomy)
+
+Apple Watch / Fitness exposes many workout types. For v1, adopt a **curated subset** mapped to our `cardio_kind` + `tracking_type` model rather than 80+ Apple types.
+
+### Tier 1 — implement first (running focus)
+
+| Apple type | Our `cardio_kind` | Primary fields | Progress metric |
+|------------|-------------------|----------------|-----------------|
+| Outdoor Run | `distance` | distance, duration | pace (min/km or min/mi), weekly distance |
+| Indoor Run / Treadmill | `distance` | distance, duration | pace, weekly distance |
+| Outdoor Walk | `distance` | distance, duration | pace, weekly distance |
+| Indoor Walk | `distance` | distance, duration | pace, weekly distance |
+
+### Tier 2 — same `distance` kind, different exercise presets
+
+| Apple type | Notes |
+|------------|-------|
+| Hiking | distance + duration + optional elevation (future) |
+| Cycling (Outdoor/Indoor) | distance + duration → speed instead of pace |
+| Rowing (Indoor/Outdoor) | distance + duration, or strokes (future) |
+| Elliptical | distance + duration |
+| Stair Stepper / Stairs | duration-first; distance optional |
+
+### Tier 3 — `duration` kind (time-only cardio)
+
+| Apple type | Primary fields |
+|------------|----------------|
+| Jump Rope | duration |
+| HIIT | duration (+ optional rounds, future) |
+| Mixed Cardio | duration |
+| Dance | duration |
+| Kickboxing | duration |
+
+### Tier 4 — `goal` kind (target-based)
+
+Apple's "goal" workouts often use open goals or distance/time targets. Map to:
+
+| Goal type | Fields | Example |
+|-----------|--------|---------|
+| Time goal | `goal_duration_seconds`, actual `duration_seconds` | "Run 30 min" |
+| Distance goal | `goal_distance_meters`, actual `distance_meters` | "Run 5 km" |
+| Open | duration only, no preset goal | "Just run" |
+
+**Reference links:**
+- [Workout types on Apple Watch](https://support.apple.com/en-us/105089)
+- [Start a workout in Fitness on iPhone](https://support.apple.com/guide/iphone/start-a-workout-in-fitness-iph8475d8510/ios)
+- [Apple Fitness+ workout types](https://support.apple.com/en-us/108761) (HIIT, Treadmill, Cycling, Rowing, Dance, Kickboxing)
+
+---
+
+## Schema changes (proposed)
+
+### Option A — extend `stretch_kind` → `activity_kind` (breaking rename)
+
+Rename `stretch_kind` to `activity_kind`: `none` | `dynamic` | `static` | `cardio_distance` | `cardio_duration` | `cardio_goal`.
+
+**Pros:** Single column, one partition function  
+**Cons:** Migration + widespread rename
+
+### Option B — add `cardio_kind` alongside `stretch_kind` (recommended)
+
+```sql
+-- New enum-like check on exercises
+ALTER TABLE exercises
+  ADD COLUMN cardio_kind text NOT NULL DEFAULT 'none'
+  CHECK (cardio_kind IN ('none', 'distance', 'duration', 'goal'));
+
+-- Cardio-specific defaults on exercise
+ALTER TABLE exercises
+  ADD COLUMN default_distance_meters numeric,
+  ADD COLUMN default_duration_seconds integer,
+  ADD COLUMN goal_distance_meters numeric,
+  ADD COLUMN goal_duration_seconds integer;
+```
+
+```sql
+-- Extend workout_sets for logged cardio data
+ALTER TABLE workout_sets
+  ADD COLUMN distance_meters numeric,
+  ADD COLUMN goal_distance_meters numeric,
+  ADD COLUMN goal_duration_seconds integer;
+-- duration_seconds already exists (used by timed stretches)
+```
+
+**Validation rules by `cardio_kind`:**
+
+| cardio_kind | Required set fields | Done gate |
+|-------------|---------------------|-----------|
+| `none` | (existing strength/stretch rules) | unchanged |
+| `distance` | `distance_meters`, `duration_seconds` | both required |
+| `duration` | `duration_seconds` | required |
+| `goal` | actual + goal fields per exercise config | both required |
+
+**Derived metrics (computed, not stored):**
+- `pace_sec_per_km = duration_seconds / (distance_meters / 1000)`
+- `speed_kmh = (distance_meters / 1000) / (duration_seconds / 3600)`
+
+---
+
+## UI changes (proposed)
+
+### Settings → Exercises
+
+- Add **Cardio kind** selector (like Stretch kind today): None / Distance / Duration / Goal
+- When cardio ≠ none:
+  - Hide RIR, reps, weight columns (like stretches hide RIR)
+  - Show cardio-specific defaults (target distance, target duration, goal fields)
+  - `muscle` could default to `"Cardio"` or a cardio subcategory (Run, Cycle, Row)
+
+### Settings → Splits
+
+- New section in split exercise list: **Cardio** (after Static stretches), same as Dynamic / Main / Static partition in [`partitionGroupsByStretchKind.ts`](../components/workout/partitionGroupsByStretchKind.ts)
+- Rename helper to `partitionGroupsByActivityKind` or add parallel cardio partition
+
+### Active workout (List + Focus)
+
+- Distance cardio: fields for **Distance** (km/mi picker) + **Duration** (or use existing timed countdown)
+- Duration cardio: duration only + optional timer (reuse [`useSetEditor`](../components/workout/useSetEditor.ts) timed flow)
+- Goal cardio: show goal vs actual (e.g. "5.0 km / 5.0 km goal")
+- No volume column (cardio excluded from volume views, like stretches)
+- No RIR
+
+### Progress page
+
+New charts (separate from strength RIR-adjusted charts in #80):
+
+| Chart | Data source |
+|-------|-------------|
+| Weekly distance by exercise | `weekly_distance_by_exercise` view |
+| Average pace trend | `weekly_pace_by_exercise` view |
+| Total cardio duration per week | `weekly_cardio_duration` view |
+
+Filter by split (reuse existing split filter pattern from [`ProgressCharts.tsx`](../components/progress/ProgressCharts.tsx)).
+
+### Home / Nav
+
+- No separate "Running" page required — cardio lives in splits like any exercise
+- Optional: Progress sub-tab or filter preset "Cardio only"
+
+---
+
+## Progress views (proposed SQL)
+
+```sql
+-- Weekly distance + pace for distance-based cardio
+CREATE VIEW weekly_distance_by_exercise AS
+SELECT
+  w.week,
+  e.id AS exercise_id,
+  e.name AS exercise,
+  e.cardio_kind,
+  SUM(ws.distance_meters) AS total_distance_meters,
+  SUM(ws.duration_seconds) AS total_duration_seconds,
+  -- weighted average pace
+  CASE WHEN SUM(ws.distance_meters) > 0
+    THEN SUM(ws.duration_seconds) / (SUM(ws.distance_meters) / 1000.0)
+    ELSE NULL END AS avg_pace_sec_per_km
+FROM workout_sets ws
+JOIN workouts w ON w.id = ws.workout_id
+JOIN exercises e ON e.id = ws.exercise_id
+WHERE w.status = 'completed'
+  AND ws.completed_at IS NOT NULL
+  AND e.cardio_kind = 'distance'
+GROUP BY w.week, e.id, e.name, e.cardio_kind;
+```
+
+Similar views for `duration` and `goal` kinds.
+
+---
+
+## Implementation phases
+
+### Phase C1 — Schema + exercise settings
+- Migration: `cardio_kind` + set columns
+- Exercise settings form: cardio kind selector + defaults
+- Seed example: "Outdoor Run" on a Rest day or dedicated Cardio split
+
+### Phase C2 — Active workout logging
+- Extend `isSetReadyToComplete` for cardio kinds
+- List + Focus field layouts for distance/duration/goal
+- Unit tests for validation + pace calculation (`lib/cardioMetrics.ts`)
+
+### Phase C3 — Split integration
+- Cardio section in split settings + active workout partition
+- Pre-fill from last session (distance, duration, pace targets)
+
+### Phase C4 — Progress charts
+- SQL views for distance, pace, duration
+- `CardioProgressCharts` component or extend `ProgressCharts`
+- Split filter support
+
+### Phase C5 — Polish
+- km/mi user preference (profile setting)
+- Goal progress indicator ("92% of distance goal")
+- Preset distances (5K, 10K) like Apple Time to Run
+
+---
+
+## Out of scope for v1
+
+- GPS / live route tracking
+- Apple Health / Strava import
+- Elevation, heart rate, cadence
+- Audio coaching (Apple Time to Run style)
+- Separate `runs` table detached from workout flow
+
+---
+
+## Open questions (decide before implementation)
+
+1. **Distance units:** Store meters internally, display km vs mi from profile preference?
+2. **`cardio_kind` vs extending `stretch_kind`:** Option B (separate column) recommended — keeps stretch logic untouched.
+3. **Cardio in volume views:** Exclude entirely (like stretches) — yes.
+4. **Single cardio exercise per split or many:** Many (e.g. Run + Row + HIIT same day).
+5. **Warmup sets for cardio:** `set_type` still exists in DB but UI was removed (#63). Cardio should not depend on warmup filtering — use `completed_at IS NOT NULL` only.
+
+---
+
+## Files likely touched (when implemented)
+
+| Area | Files |
+|------|-------|
+| Schema | `supabase/migrations/YYYYMMDD_add_cardio_kind.sql` |
+| Types | `lib/database.types.ts` |
+| Validation | `lib/setCompletion.ts`, `lib/cardioMetrics.ts` |
+| Settings | `components/settings/ExerciseSettingsClient.tsx`, `SplitSettingsClient.tsx` |
+| Workout UI | `ActiveWorkout.tsx`, `FocusSetCard.tsx`, `partitionGroupsByStretchKind.ts` |
+| Actions | `app/actions/exercises.ts`, `app/actions/workouts.ts` |
+| Progress | `app/progress/page.tsx`, `components/progress/ProgressCharts.tsx` |
+| Tests | `lib/cardioMetrics.test.ts`, `lib/setCompletion.test.ts` |
+
+---
+
+## Acceptance criteria
+
+- [ ] User can create an "Outdoor Run" exercise with `cardio_kind = distance` and add it to a split
+- [ ] During active workout, user logs distance + duration and marks set Done
+- [ ] Pace is computed and visible on completed workout summary
+- [ ] Progress page shows weekly distance and pace trend for cardio exercises
+- [ ] Cardio exercises do not appear in strength volume charts
+- [ ] Duration-only cardio (Jump Rope) works with timer flow
+- [ ] Goal-based cardio shows progress toward configured target

--- a/lib/setCompletion.test.ts
+++ b/lib/setCompletion.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { incompleteSets, isSetReadyToComplete } from "./setCompletion";
+import { incompleteSets, isSetReadyToComplete, getFinishModalState } from "./setCompletion";
 
 describe("isSetReadyToComplete", () => {
   it("requires reps, weight, and rir for weighted exercises", () => {
@@ -201,5 +201,33 @@ describe("incompleteSets", () => {
       },
     ];
     expect(incompleteSets(sets)).toHaveLength(1);
+  });
+});
+
+describe("getFinishModalState", () => {
+  it("allows finish when all sets are marked Done", () => {
+    const state = getFinishModalState([
+      {
+        exercise_name: "Bench",
+        set_number: 1,
+        set_type: "working",
+        completed_at: "2026-01-01T00:00:00Z",
+      },
+    ]);
+    expect(state.canFinish).toBe(true);
+    expect(state.confirmLabel).toBe("Finish workout");
+  });
+
+  it("blocks finish and lists undone sets", () => {
+    const state = getFinishModalState([
+      {
+        exercise_name: "Bench",
+        set_number: 1,
+        set_type: "working",
+        completed_at: null,
+      },
+    ]);
+    expect(state.canFinish).toBe(false);
+    expect(state.description).toContain("Bench set 1");
   });
 });

--- a/lib/setCompletion.test.ts
+++ b/lib/setCompletion.test.ts
@@ -60,7 +60,20 @@ describe("isSetReadyToComplete", () => {
         rir: 2,
         duration_seconds: null,
       }),
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  it("bodyweight stretch at 0 extra weight with empty presets is ready", () => {
+    expect(
+      isSetReadyToComplete({
+        tracking_type: "bodyweight",
+        stretch_kind: "static",
+        reps: 10,
+        weight: 0,
+        rir: null,
+        duration_seconds: null,
+      }),
+    ).toBe(true);
   });
 
   it("uses duration instead of reps for timed exercises", () => {

--- a/lib/setCompletion.ts
+++ b/lib/setCompletion.ts
@@ -69,3 +69,27 @@ export function formatUndoneSetsMessage(rows: UndoneSetRow[]): string | null {
   }
   return `Mark Done on these sets before finishing: ${labels.join(", ")}.`;
 }
+
+export function getFinishModalState(rows: UndoneSetRow[]): {
+  canFinish: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+} {
+  const undoneMessage = formatUndoneSetsMessage(rows);
+  if (!undoneMessage) {
+    return {
+      canFinish: true,
+      title: "Finish workout?",
+      description:
+        "All sets are marked Done. This marks the session complete and returns home. You can review it in History.",
+      confirmLabel: "Finish workout",
+    };
+  }
+  return {
+    canFinish: false,
+    title: "Sets still need Done",
+    description: undoneMessage,
+    confirmLabel: "Mark all sets Done first",
+  };
+}

--- a/lib/setCompletion.ts
+++ b/lib/setCompletion.ts
@@ -26,8 +26,10 @@ export function isSetReadyToComplete(set: SetCompletionInput): boolean {
       : set.reps != null;
   if (!hasRepsOrDuration) return false;
 
-  if (usesLoggedWeightColumn(set.tracking_type) && set.weight == null) {
-    return false;
+  if (usesLoggedWeightColumn(set.tracking_type)) {
+    const weight =
+      set.tracking_type === "bodyweight" ? (set.weight ?? 0) : set.weight;
+    if (weight == null) return false;
   }
 
   if (!isStretch(set) && set.rir == null) return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Active workout UX improvements:

- **#77** — Persist Focus view step in `sessionStorage` (by set ID) so returning to the workout resumes the current exercise
- **#81** — Finish modal lists undone sets and disables confirm until all sets are marked Done
- **#79** — Newly assigned split exercises sync into an active draft workout via `syncExerciseToActiveDraft`

Depends on Phase 1 quick fixes branch.

## Testing

- `npm test` — 64 tests passing
- `npm run build` — succeeds

Closes #77
Closes #81
Closes #79
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f57c4-449a-7499-94f3-43090dbe0325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f57c4-449a-7499-94f3-43090dbe0325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

