### PR TITLE
fix: resolve set-state-in-effect lint errors in ActiveWorkout

### DIFF
--- a/components/workout/ActiveWorkout.tsx
+++ b/components/workout/ActiveWorkout.tsx
@@ -40,6 +40,29 @@ const FOCUS_STEP_STORAGE_PREFIX = "gym-app:focusStep:";
 
 type ViewMode = "list" | "focus";
 
+function getInitialFocusIndex(
+  rows: FlatSetRow[],
+  focusStepStorageKey: string,
+  readOnly: boolean,
+): number {
+  if (typeof window === "undefined" || readOnly) return 0;
+
+  const focusSteps = buildFocusSteps(groupFlatSets(rows));
+  if (focusSteps.length === 0) return 0;
+
+  const saved = window.sessionStorage.getItem(focusStepStorageKey);
+  if (saved) {
+    const idx = focusSteps.findIndex((s) => s.setId === saved);
+    if (idx >= 0) return idx;
+  }
+
+  const firstIncomplete = focusSteps.findIndex((step) => {
+    const row = rows.find((r) => r.id === step.setId);
+    return row && row.set_type !== "warmup" && row.completed_at == null;
+  });
+  return firstIncomplete >= 0 ? firstIncomplete : 0;
+}
+
 function SetTableRow({
   row,
   weightPresets,
@@ -551,20 +574,21 @@ export function ActiveWorkout({
     const raw = window.sessionStorage.getItem(viewModeStorageKey);
     return raw === "focus" ? "focus" : "list";
   });
-  const [focusIndex, setFocusIndex] = useState(0);
+  const [focusIndex, setFocusIndex] = useState(() =>
+    getInitialFocusIndex(rows, focusStepStorageKey, readOnly),
+  );
   const [focusNoteTarget, setFocusNoteTarget] = useState<{
     setId: string;
     draft: string;
   } | null>(null);
 
   const [localRows, setLocalRows] = useState(() => rows);
-
+  const [prevRows, setPrevRows] = useState(rows);
   // Pick up server-refreshed rows (e.g. exercise added to split mid-workout, #79).
-  useEffect(() => {
+  if (rows !== prevRows) {
+    setPrevRows(rows);
     setLocalRows(rows);
-  }, [rows]);
-
-  const focusRestoredRef = useRef(false);
+  }
 
   // Rest should only fire the first time a set is marked Done — re-editing
   // and re-completing a set (Edit → Done again) is a correction, not a new
@@ -619,29 +643,6 @@ export function ActiveWorkout({
       Notification.requestPermission();
     }
   }, []);
-
-  // Restore Focus position after leaving and returning to the workout (#77).
-  useEffect(() => {
-    if (readOnly || focusRestoredRef.current || focusSteps.length === 0) return;
-    focusRestoredRef.current = true;
-
-    const saved = window.sessionStorage.getItem(focusStepStorageKey);
-    if (saved) {
-      const idx = focusSteps.findIndex((s) => s.setId === saved);
-      if (idx >= 0) {
-        setFocusIndex(idx);
-        return;
-      }
-    }
-
-    const firstIncomplete = focusSteps.findIndex((step) => {
-      const row = localRows.find((r) => r.id === step.setId);
-      return row && row.set_type !== "warmup" && row.completed_at == null;
-    });
-    if (firstIncomplete >= 0) {
-      setFocusIndex(firstIncomplete);
-    }
-  }, [focusSteps, localRows, readOnly, focusStepStorageKey]);
 
   // Refresh server rows when returning to the tab (e.g. after settings sync, #79).
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes CI `npm run lint` failures in `ActiveWorkout.tsx`.

## Changes

- **Server row sync (#79):** Replaced `useEffect(() => setLocalRows(rows))` with React's render-time prop reconciliation pattern (`prevRows` + conditional `setLocalRows`).
- **Focus position restore (#77):** Moved sessionStorage restore into lazy `useState` via new `getInitialFocusIndex()` helper instead of a mount effect.

## Verification

- `npm run lint` — passes
- `npm test` — 64 tests passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f57c4-449a-7499-94f3-43090dbe0325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f57c4-449a-7499-94f3-43090dbe0325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

