### PR TITLE
Fix progress charts: restore history and split filtering

### DIFF
--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -24,6 +24,9 @@ export default async function ProgressPage() {
   if (monthlyRes.error) {
     throw new Error(monthlyRes.error.message);
   }
+  if (splitWeeklyRes.error) {
+    throw new Error(splitWeeklyRes.error.message);
+  }
 
   const rows = [...(weeklyRes.data ?? [])].sort(
     (a, b) =>

--- a/components/progress/ProgressCharts.tsx
+++ b/components/progress/ProgressCharts.tsx
@@ -180,6 +180,13 @@ export function ProgressCharts({
         </div>
       )}
 
+      {split && exercises.length === 0 ? (
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+          No logged sets for this split yet. Finish a workout with exercises
+          assigned to {split}.
+        </p>
+      ) : null}
+
       <section className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
         <div className="flex flex-wrap items-end gap-3">
           <h2 className="text-base font-semibold">Overall trends</h2>

--- a/supabase/migrations/20260713000000_backfill_set_completed_at_for_progress.sql
+++ b/supabase/migrations/20260713000000_backfill_set_completed_at_for_progress.sql
@@ -1,0 +1,38 @@
+-- Restore historical progress data excluded by rep-capacity views (#80).
+-- Pre-#73 completed sets never received completed_at; backfill from workout timestamps.
+-- Also fix split filtering to use exercise_splits (catalog splits) instead of workouts.split.
+
+update public.workout_sets ws
+set completed_at = coalesce(
+  w.completed_at,
+  (w.date::timestamp at time zone 'UTC'),
+  w.created_at,
+  now()
+)
+from public.workouts w
+join public.exercises e on e.id = ws.exercise_id
+where ws.workout_id = w.id
+  and w.status = 'completed'
+  and ws.completed_at is null
+  and ws.reps is not null
+  and coalesce(e.stretch_kind, 'none') = 'none';
+
+create or replace view public.weekly_rep_capacity_by_split
+with (security_invoker = true) as
+select
+  w.week,
+  es.split_name as split,
+  e.name as exercise,
+  e.muscle,
+  max(coalesce(ws.reps, 0) + coalesce(ws.rir, 0))::numeric as max_rep_capacity
+from public.workout_sets ws
+join public.workouts w on w.id = ws.workout_id
+join public.exercises e on e.id = ws.exercise_id
+join public.exercise_splits es on es.exercise_id = e.id
+where w.status = 'completed'
+  and ws.completed_at is not null
+  and coalesce(e.stretch_kind, 'none') = 'none'
+  and ws.reps is not null
+group by w.week, es.split_name, e.name, e.muscle;
+
+grant select on public.weekly_rep_capacity_by_split to anon, authenticated;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes broken Progress charts where historical data disappeared after the rep-capacity migration (#80).

**Root causes:**
1. Rep-capacity views require `workout_sets.completed_at`, but legacy completed sets were never backfilled when that column was added (#73).
2. Split filter used `workouts.split` text, so Push/Pull/Legs showed empty dropdowns when history was logged under old split names (Upper A/B).

## Changes

- **Migration** `20260713000000_backfill_set_completed_at_for_progress.sql`:
  - Backfills `completed_at` on completed-workout sets missing it (uses workout `completed_at` / `date`)
  - Rebuilds `weekly_rep_capacity_by_split` to join `exercise_splits` for catalog-based split filtering
- **`app/progress/page.tsx`**: throw on `splitWeeklyRes.error` (was silently `[]`)
- **`ProgressCharts.tsx`**: helper text when a split filter has no logged sets

## Behavior

- Old progression restored: `rep capacity = reps + coalesce(rir, 0)` — existing RIR kept, null RIR counts as 0
- New sets still require explicit Done tap going forward
- Push/Pull filters show exercises assigned in Settings, including history from workouts logged under renamed splits

## Verification

- [x] 74 unit tests pass
- [x] ESLint + `tsc --noEmit` clean
- [ ] After migration deploys to production: Progress → Push should list exercises; Legs charts should show multi-week history (not single W28 point)

## Deploy note

This fix requires the Supabase migration to run on production (`supabase db push` or CI migration step).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9f2d129-d4c2-4acc-99c4-3c1ad2bda6b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9f2d129-d4c2-4acc-99c4-3c1ad2bda6b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

